### PR TITLE
Refresh token not running on main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+UPCOMING
+____
+
+* Fixed an issue on iOS where `refreshToken` was not running on main thread.
+
 8.1.2
 ----
 

--- a/ios/RNBatch.m
+++ b/ios/RNBatch.m
@@ -126,7 +126,9 @@ RCT_EXPORT_METHOD(push_requestProvisionalNotificationAuthorization)
 
 RCT_EXPORT_METHOD(push_refreshToken)
 {
-    [BatchPush refreshToken];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [BatchPush refreshToken];
+    });
 }
 
 RCT_EXPORT_METHOD(push_setShowForegroundNotification:(BOOL) enabled)


### PR DESCRIPTION
* Fixed an issue on iOS where `refreshToken` was not running on main thread.