### PR TITLE
expo: fix rnbatch import during pre-build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+9.0.1
+----
+
+**Expo**
+
+* Fixed an issue on iOS where the `RNBatch` import was not added during the Expo pre-build.
+
 9.0.0
 ----
 

--- a/plugin/src/fixtures/appDelegate.ts
+++ b/plugin/src/fixtures/appDelegate.ts
@@ -157,6 +157,8 @@ static void InitializeFlipper(UIApplication *application) {
 
 export const appDelegateExpectedFixture = `#import "AppDelegate.h"
 
+#import <RNBatchPush/RNBatch.h>
+
 #if defined(EX_DEV_MENU_ENABLED)
 @import EXDevMenu;
 #endif

--- a/plugin/src/ios/withReactNativeBatchAppDelegate.ts
+++ b/plugin/src/ios/withReactNativeBatchAppDelegate.ts
@@ -3,9 +3,12 @@ import { ConfigPlugin, withAppDelegate } from '@expo/config-plugins';
 const DID_FINISH_LAUNCHING_WITH_OPTIONS_DECLARATION =
   '- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions\n{';
 
+const IMPORT_BATCH = '\n\n#import <RNBatchPush/RNBatch.h>\n';
 const REGISTER_BATCH = '\n  [RNBatch start];\n';
 
 export const modifyAppDelegate = (contents: string) => {
+  contents = contents.replace('\n', IMPORT_BATCH);
+
   const [beforeDeclaration, afterDeclaration] = contents.split(DID_FINISH_LAUNCHING_WITH_OPTIONS_DECLARATION);
 
   const newAfterDeclaration = DID_FINISH_LAUNCHING_WITH_OPTIONS_DECLARATION.concat(REGISTER_BATCH).concat(afterDeclaration);


### PR DESCRIPTION
* Fixed an issue on iOS where the `RNBatch` import was not added during the Expo pre-build.