### PR TITLE
profile: prevent accidental "undefined" as profile identifier

### DIFF
--- a/src/BatchProfile.ts
+++ b/src/BatchProfile.ts
@@ -48,6 +48,9 @@ export const BatchProfile = {
    * If a profile already exists, this device will be attached to it. Must not be longer than 1024 characters.
    */
   identify: (identifier: string | null): void => {
+    if (typeof identifier === 'undefined') {
+      return;
+    }
     RNBatch.profile_identify(identifier);
   },
 


### PR DESCRIPTION
Si on utilise pas typescript, il est relativement facile de mettre l'identifier `"undefined"` sur un profil en passant une variable mal initialisée.

Le contrat API etant d'explicitement passer null pour enlever l'identifier, je pense qu'il faut qu'on refuse plutot que convertir en null.
Autant on peut se dire que `identify()` pourrait etre interprété en logout, autant si on fait `identify(myID)` mais que `myID` n'est accidentellement pas defined, c'est plus dur a débugger

Deux autres pistes:
 - Ajouter un log ?
 - Bloquer les "usual suspects" coté natif (undefined, null, (null), nil, `[object Object]`) pour être sur qu'on oublie pas ça dans d'autres plugins