### PR TITLE
Expo push notification entitlement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ UPCOMING
 
 * Removed deprecated API `registerForRemoteNotifications`. Please use `requestNotificationAuthorization` to request permission when needed, and `requestToken` at each app launch.
 
+**Expo**
+
+* Batch now automatically adds Apple push notification entitlement since it was removed from Expo SDK 51.
+
 
 9.0.2
 ----

--- a/plugin/src/ios/withReactNativeBatchEntitlements.ts
+++ b/plugin/src/ios/withReactNativeBatchEntitlements.ts
@@ -1,0 +1,8 @@
+import { ConfigPlugin, withEntitlementsPlist } from '@expo/config-plugins';
+
+export const withReactNativeBatchEntitlements: ConfigPlugin<object | void> = config => {
+  return withEntitlementsPlist(config, config => {
+    config.modResults = { ...config.modResults, 'aps-environment': 'development' };
+    return config;
+  });
+};

--- a/plugin/src/withReactNativeBatch.ts
+++ b/plugin/src/withReactNativeBatch.ts
@@ -1,11 +1,12 @@
 import { ConfigPlugin, createRunOncePlugin } from '@expo/config-plugins';
-import { withClassPath, withApplyPlugin, withGoogleServicesFile } from '@expo/config-plugins/build/android/GoogleServices';
+import { withApplyPlugin, withClassPath, withGoogleServicesFile } from '@expo/config-plugins/build/android/GoogleServices';
 
 import { withReactNativeBatchAppBuildGradle } from './android/withReactNativeBatchAppBuildGradle';
 import { withReactNativeBatchMainActivity } from './android/withReactNativeBatchMainActivity';
 import { withReactNativeBatchMainApplication } from './android/withReactNativeBatchMainApplication';
 import { withReactNativeBatchManifest } from './android/withReactNativeBatchManifest';
 import { withReactNativeBatchAppDelegate } from './ios/withReactNativeBatchAppDelegate';
+import { withReactNativeBatchEntitlements } from './ios/withReactNativeBatchEntitlements';
 import { withReactNativeBatchInfoPlist } from './ios/withReactNativeBatchInfoPlist';
 
 export type Props = {
@@ -30,6 +31,7 @@ const withReactNativeBatch: ConfigPlugin<Props | void> = (config, props) => {
   newConfig = withReactNativeBatchMainApplication(newConfig);
   newConfig = withReactNativeBatchMainActivity(newConfig);
   newConfig = withReactNativeBatchInfoPlist(newConfig, _props);
+  newConfig = withReactNativeBatchEntitlements(newConfig);
   newConfig = withReactNativeBatchAppDelegate(newConfig);
   // Return the modified config.
   return newConfig;


### PR DESCRIPTION
- Batch now automatically adds Apple push notification entitlement since it was removed from Expo SDK 51.
