### PR TITLE
Add inbox silent notifications support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ UPCOMING
 - Added `messagingCustomPayload` property to `BatchMessagingEventPayload` (only for In-App Message).
 - Added `pushPayload` property to `BatchMessagingEventPayload` (only for Landing Mobile).
 
+**Inbox**
+- Added `isSilent` property to `IInboxNotification`.
+- Added `setFilterSilentNotifications` method to `BatchInboxFetcher`. Default value is true.
+- ⚠️ BREAKING: `body` property from `IInboxNotification` is now nullable since the inbox fetcher may not filter silent notifications.
+
 
 9.0.2
 ----

--- a/android/src/main/java/com/batch/batch_rn/RNBatchInbox.java
+++ b/android/src/main/java/com/batch/batch_rn/RNBatchInbox.java
@@ -51,6 +51,7 @@ public class RNBatchInbox {
         output.putString("identifier", notification.getNotificationIdentifier());
         output.putString("body", notification.getBody());
         output.putBoolean("isUnread", notification.isUnread());
+        output.putBoolean("isSilent", notification.isSilent());
         output.putDouble("date", notification.getDate().getTime());
 
         int source = 0; // UNKNOWN

--- a/android/src/main/java/com/batch/batch_rn/RNBatchModuleImpl.java
+++ b/android/src/main/java/com/batch/batch_rn/RNBatchModuleImpl.java
@@ -459,6 +459,15 @@ public class RNBatchModuleImpl {
         promise.resolve(null);
     }
 
+    public void inbox_fetcher_setFilterSilentNotifications(String fetcherIdentifier, boolean filterSilentNotifications, Promise promise) {
+        if (!this.batchInboxFetcherMap.containsKey(fetcherIdentifier)) {
+            promise.reject("InboxError", "FETCHER_NOT_FOUND");
+            return;
+        }
+        BatchInboxFetcher fetcher = this.batchInboxFetcherMap.get(fetcherIdentifier);
+        fetcher.setFilterSilentNotifications(filterSilentNotifications);
+    }
+
     // USER MODULE
 
     public void user_getInstallationId(Promise promise) {

--- a/android/src/newarch/java/com/batch/batch_rn/RNBatchModule.java
+++ b/android/src/newarch/java/com/batch/batch_rn/RNBatchModule.java
@@ -197,6 +197,11 @@ public class RNBatchModule extends NativeRNBatchModuleSpec {
         impl.inbox_fetcher_displayLandingMessage(getCurrentActivity(), fetcherIdentifier, notificationIdentifier, promise);
     }
 
+    @Override
+    public void inbox_fetcher_setFilterSilentNotifications(String fetcherIdentifier, boolean filterSilentNotifications, Promise promise) {
+        impl.inbox_fetcher_setFilterSilentNotifications(fetcherIdentifier, filterSilentNotifications, promise);
+    }
+
     // USER MODULE
 
     @Override

--- a/android/src/oldarch/java/com/batch/batch_rn/RNBatchModule.java
+++ b/android/src/oldarch/java/com/batch/batch_rn/RNBatchModule.java
@@ -203,6 +203,11 @@ public class RNBatchModule extends ReactContextBaseJavaModule {
         impl.inbox_fetcher_displayLandingMessage(getCurrentActivity(), fetcherIdentifier, notificationIdentifier, promise);
     }
 
+    @ReactMethod
+    public void inbox_fetcher_setFilterSilentNotifications(String fetcherIdentifier, boolean filterSilentNotifications, final Promise promise) {
+        impl.inbox_fetcher_setFilterSilentNotifications(fetcherIdentifier, filterSilentNotifications, promise);
+    }
+
     // USER MODULE
 
     @ReactMethod

--- a/ios/RNBatch.mm
+++ b/ios/RNBatch.mm
@@ -791,6 +791,24 @@ RCT_EXPORT_METHOD(inbox_fetcher_displayLandingMessage:
     resolve([NSNull null]);
 }
 
+RCT_EXPORT_METHOD(inbox_fetcher_setFilterSilentNotifications:
+                  (NSString *) fetcherIdentifier
+                  filterSilentNotifications:
+                  (BOOL) filterSilentNotifications
+                  resolve:
+                  (RCTPromiseResolveBlock) resolve
+                  reject:
+                  (RCTPromiseRejectBlock) reject) {
+    BatchInboxFetcher* fetcher = _batchInboxFetcherMap[fetcherIdentifier];
+    if (!fetcher) {
+        reject(@"InboxError", @"FETCHER_NOT_FOUND", nil);
+        return;
+    }
+
+    [fetcher setFilterSilentNotifications:filterSilentNotifications];
+    resolve([NSNull null]);
+}
+
 
 RCT_EXPORT_METHOD(inbox_fetcher_fetchNewNotifications:
                   (NSString *) fetcherIdentifier
@@ -871,22 +889,26 @@ RCT_EXPORT_METHOD(inbox_fetcher_fetchNextPage:
     }
 
     NSString *title = notification.message.title;
+    NSString *body = notification.message.body;
 
     NSDictionary *output = @{
         @"identifier": notification.identifier,
-        @"body": notification.message.body,
         @"isUnread": @(notification.isUnread),
+        @"isSilent": @(notification.isSilent),
         @"date": [NSNumber numberWithDouble:notification.date.timeIntervalSince1970 * 1000],
         @"source": source,
         @"payload": notification.payload,
         @"hasLandingMessage": @(notification.hasLandingMessage)
     };
 
+    NSMutableDictionary *mutableOutput = [output mutableCopy];
     if (title != nil) {
-        NSMutableDictionary *mutableOutput = [output mutableCopy];
         mutableOutput[@"title"] = title;
-        output = mutableOutput;
     }
+    if (body != nil) {
+        mutableOutput[@"body"] = body;
+    }
+    output = mutableOutput;
     return output;
 }
 

--- a/ios/RNBatch.mm
+++ b/ios/RNBatch.mm
@@ -786,9 +786,10 @@ RCT_EXPORT_METHOD(inbox_fetcher_displayLandingMessage:
         reject(@"InboxError", @"NOTIFICATION_NOT_FOUND", nil);
         return;
     }
-
-    [notification displayLandingMessage];
-    resolve([NSNull null]);
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [notification displayLandingMessage];
+        resolve([NSNull null]);
+    });
 }
 
 RCT_EXPORT_METHOD(inbox_fetcher_setFilterSilentNotifications:

--- a/src/BatchInbox.ts
+++ b/src/BatchInbox.ts
@@ -20,9 +20,9 @@ export interface IInboxNotification {
   title?: string;
 
   /**
-   * Notification alert body
+   * Notification alert body (if notification not silent)
    */
-  body: string;
+  body?: string;
 
   /**
    * URL of the rich notification attachment (image/audio/video) - iOS Only
@@ -43,6 +43,11 @@ export interface IInboxNotification {
    * Flag indicating whether this notification is unread or not
    */
   isUnread: boolean;
+
+  /**
+   * Flag indicating whether this notification is silent or not
+   */
+  isSilent: boolean;
 
   /**
    * The push notification's source, indicating what made Batch send it.

--- a/src/BatchInboxFetcher.ts
+++ b/src/BatchInboxFetcher.ts
@@ -119,7 +119,7 @@ const parseNotifications = (notifications: IInboxNotification[]): IInboxNotifica
         ...notification,
         payload: {
           ...(notification.payload as Record<string, unknown>),
-          'com.batch': JSON.parse(batchPayload),
+          'com.batch': typeof batchPayload == 'string' ? JSON.parse(batchPayload) : batchPayload,
         },
       };
     } catch (error) {

--- a/src/BatchInboxFetcher.ts
+++ b/src/BatchInboxFetcher.ts
@@ -66,6 +66,16 @@ export class BatchInboxFetcher {
   }
 
   /**
+   * Sets whether the SDK should filter silent notifications (pushes that don't result in a message being
+   * shown to the user). Default: true
+   *
+   * @param filterSilentNotifications Whether the SDK should filter silent notifications
+   */
+  public setFilterSilentNotifications(filterSilentNotifications: boolean): Promise<void> {
+    return RNBatch.inbox_fetcher_setFilterSilentNotifications(this.identifier, filterSilentNotifications);
+  }
+
+  /**
    * Fetches new notifications (and resets pagination to 0).
    *
    * Usually used as an initial fetch and refresh method in an infinite list.

--- a/src/NativeRNBatchModule.ts
+++ b/src/NativeRNBatchModule.ts
@@ -65,6 +65,7 @@ export interface Spec extends TurboModule {
     endReached: boolean;
   }>;
   inbox_fetcher_displayLandingMessage(fetcherIdentifier: string, notificationIdentifier: string): Promise<void>;
+  inbox_fetcher_setFilterSilentNotifications(fetcherIdentifier: string, filterSilentNotifications: boolean): Promise<void>;
 
   // User Module
   user_getInstallationId(): Promise<string>;


### PR DESCRIPTION
**Inbox**
- Added `isSilent` property to `IInboxNotification`.
- Added `setFilterSilentNotifications` method to `BatchInboxFetcher`. Default value is true.
- ⚠️ BREAKING: `body` property from `IInboxNotification` is now nullable since the inbox fetcher may not filter silent notifications.