### PR TITLE
Fix codegen build error

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -11,7 +11,6 @@ __snapshots/**
 .prettierignore
 tsconfig.json
 jest.config.js
-src
 docs
 
 #IntellIJ

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+10.0.1
+----
+
+**Plugin**
+- Fixed a build issue related to Codegen.
+- Batch now publish TypeScript source files since Codegen does not support DTS files for Turbo Module Specifications.
+
 10.0.0
 ----
 

--- a/android/src/main/java/com/batch/batch_rn/RNBatchModuleImpl.java
+++ b/android/src/main/java/com/batch/batch_rn/RNBatchModuleImpl.java
@@ -54,7 +54,7 @@ public class RNBatchModuleImpl {
 
     private static final String PLUGIN_VERSION_ENVIRONMENT_VARIABLE = "batch.plugin.version";
 
-    public static final String PLUGIN_VERSION = "ReactNative/10.0.0";
+    public static final String PLUGIN_VERSION = "ReactNative/10.0.1";
 
     public static final String LOGGER_TAG = "RNBatchBridge";
 

--- a/ios/RNBatch.h
+++ b/ios/RNBatch.h
@@ -1,7 +1,7 @@
 #import <React/RCTEventEmitter.h>
 #import <Batch/Batch.h>
 
-#define PluginVersion "ReactNative/10.0.0"
+#define PluginVersion "ReactNative/10.0.1"
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #import <RNBatchSpec/RNBatchSpec.h>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@batch.com/react-native-plugin",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "Batch.com React-Native Plugin",
   "homepage": "https://github.com/BatchLabs/Batch-React-Native-Plugin",
   "main": "dist/Batch.js",


### PR DESCRIPTION
**Plugin**
- Fixed a build issue related to Codegen.
- Batch now publish TypeScript source files since Codegen does not support DTS files for Turbo Module Specifications.
