### PR TITLE
Release 10.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,8 @@ jobs:
   build_and_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
             node-version: '18'
             cache: 'yarn'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,8 +5,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
             node-version: '18'
             cache: 'yarn'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
             node-version: '18'
             cache: 'yarn'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Added Swift/Objective-C compatibility. You can now directly import module `RNBatchPush` into your swift files.
 
 **Expo**
-- Added support for Expo SDK 53.
+- Added support for Expo SDK 53. Since, as of writing, it is still under preview version, this may not works in future versions.
 
 **Core**
 - Fixed an issue where opting the SDK after been opted-out would unexpectedly reset default configurations, such as Do Not Disturb setting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,20 @@
+10.1.0
+----
+
+**Plugin**
+- Added Swift/Objective-C compatibility. You can now directly import module `RNBatchPush` into your swift files.
+
+**Expo**
+- Added support for Expo SDK 53.
+
+
 10.0.1
 ----
 
 **Plugin**
 - Fixed a build issue related to Codegen.
 - Batch now publish TypeScript source files since Codegen does not support DTS files for Turbo Module Specifications.
+
 
 10.0.0
 ----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 **Expo**
 - Added support for Expo SDK 53.
 
+**Core**
+- Fixed an issue where opting the SDK after been opted-out would unexpectedly reset default configurations, such as Do Not Disturb setting.
+
 
 10.0.1
 ----

--- a/RNBatchPush.podspec
+++ b/RNBatchPush.podspec
@@ -16,5 +16,6 @@ Pod::Spec.new do |s|
 
   s.dependency "React"
   s.dependency 'Batch', '~> 2.1.0'
-  s.module_map   = "ios/RNBatch.modulemap"
+
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end

--- a/RNBatchPush.podspec
+++ b/RNBatchPush.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
 
   s.dependency "React"
   s.dependency 'Batch', '~> 2.1.0'
-
+  s.module_map   = "ios/RNBatch.modulemap"
 end

--- a/ios/RNBatch.h
+++ b/ios/RNBatch.h
@@ -1,7 +1,7 @@
 #import <React/RCTEventEmitter.h>
 #import <Batch/Batch.h>
 
-#define PluginVersion "ReactNative/10.0.1"
+#define PluginVersion "ReactNative/10.1.0"
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #import <RNBatchSpec/RNBatchSpec.h>

--- a/ios/RNBatch.mm
+++ b/ios/RNBatch.mm
@@ -117,10 +117,19 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_METHOD(optIn:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 {
-    [BatchSDK optIn];
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [RNBatch start];
-    });
+    if (BatchSDK.isOptedOut) {
+        // Opt-in SDK
+        [BatchSDK optIn];
+        
+        // Get API key and restart sdk
+        NSDictionary *info = [[NSBundle mainBundle] infoDictionary];
+        NSString *batchAPIKey = [info objectForKey:@"BatchAPIKey"];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [BatchSDK startWithAPIKey:batchAPIKey];
+        });
+    } else {
+        NSLog(@"RNBatch: Batch SDK is already opted-in");
+    }
     resolve([NSNull null]);
 }
 

--- a/ios/RNBatch.modulemap
+++ b/ios/RNBatch.modulemap
@@ -1,0 +1,7 @@
+framework module RNBatch {
+    
+    umbrella header "RNBatch.h"
+    
+    export *
+    module * { export * }
+}

--- a/ios/RNBatch.modulemap
+++ b/ios/RNBatch.modulemap
@@ -1,7 +1,0 @@
-framework module RNBatch {
-    
-    umbrella header "RNBatch.h"
-    
-    export *
-    module * { export * }
-}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@batch.com/react-native-plugin",
-  "version": "10.0.1",
+  "version": "10.1.0",
   "description": "Batch.com React-Native Plugin",
   "homepage": "https://github.com/BatchLabs/Batch-React-Native-Plugin",
   "main": "dist/Batch.js",

--- a/plugin/src/__tests__/withReactNativeBatchAppDelegate.test.ts
+++ b/plugin/src/__tests__/withReactNativeBatchAppDelegate.test.ts
@@ -1,4 +1,5 @@
 import { appDelegateExpectedFixture, appDelegateFixture } from '../fixtures/appDelegate';
+import { swift_appDelegateExpectedFixture, swift_appDelegateFixture } from '../fixtures/swift_appDelegate';
 import { modifyAppDelegate } from '../ios/withReactNativeBatchAppDelegate';
 
 describe(modifyAppDelegate, () => {
@@ -6,5 +7,13 @@ describe(modifyAppDelegate, () => {
     const result = modifyAppDelegate(appDelegateFixture);
 
     expect(result).toEqual(appDelegateExpectedFixture);
+  });
+});
+
+describe(modifyAppDelegate, () => {
+  it('should modify the swift_AppDelegate', () => {
+    const result = modifyAppDelegate(swift_appDelegateFixture);
+
+    expect(result).toEqual(swift_appDelegateExpectedFixture);
   });
 });

--- a/plugin/src/fixtures/swift_appDelegate.ts
+++ b/plugin/src/fixtures/swift_appDelegate.ts
@@ -44,7 +44,7 @@ public class AppDelegate: ExpoAppDelegate {
 
 export const swift_appDelegateExpectedFixture = `import React
 
-import RNBatch
+import RNBatchPush
 import Expo
 
 @UIApplicationMain

--- a/plugin/src/fixtures/swift_appDelegate.ts
+++ b/plugin/src/fixtures/swift_appDelegate.ts
@@ -1,0 +1,91 @@
+export const swift_appDelegateFixture = `import React
+import Expo
+
+@UIApplicationMain
+public class AppDelegate: ExpoAppDelegate {
+  public override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    self.moduleName = "main"
+    self.initialProps = [:]
+
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  public override func bundleURL() -> URL? {
+#if DEBUG
+    return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
+#else
+    return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+#endif
+  }
+
+  // Linking API
+  public override func application(
+    _ app: UIApplication,
+    open url: URL,
+    options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+  ) -> Bool {
+    return super.application(app, open: url, options: options) || RCTLinkingManager.application(app, open: url, options: options)
+  }
+
+  // Universal Links
+  public override func application(
+    _ application: UIApplication,
+    continue userActivity: NSUserActivity,
+    restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
+  ) -> Bool {
+    let result = RCTLinkingManager.application(application, continue: userActivity, restorationHandler: restorationHandler)
+    return super.application(application, continue: userActivity, restorationHandler: restorationHandler) || result
+  }
+}
+`;
+
+export const swift_appDelegateExpectedFixture = `import React
+
+import RNBatch
+import Expo
+
+@UIApplicationMain
+public class AppDelegate: ExpoAppDelegate {
+  public override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    RNBatch.start()
+
+    self.moduleName = "main"
+    self.initialProps = [:]
+
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  public override func bundleURL() -> URL? {
+#if DEBUG
+    return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
+#else
+    return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+#endif
+  }
+
+  // Linking API
+  public override func application(
+    _ app: UIApplication,
+    open url: URL,
+    options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+  ) -> Bool {
+    return super.application(app, open: url, options: options) || RCTLinkingManager.application(app, open: url, options: options)
+  }
+
+  // Universal Links
+  public override func application(
+    _ application: UIApplication,
+    continue userActivity: NSUserActivity,
+    restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
+  ) -> Bool {
+    let result = RCTLinkingManager.application(application, continue: userActivity, restorationHandler: restorationHandler)
+    return super.application(application, continue: userActivity, restorationHandler: restorationHandler) || result
+  }
+}
+`;

--- a/plugin/src/ios/withReactNativeBatchAppDelegate.ts
+++ b/plugin/src/ios/withReactNativeBatchAppDelegate.ts
@@ -1,17 +1,39 @@
 import { ConfigPlugin, withAppDelegate } from '@expo/config-plugins';
 
-const DID_FINISH_LAUNCHING_WITH_OPTIONS_DECLARATION =
+// MARK : - Objectif-c
+
+const DID_FINISH_LAUNCHING_WITH_OPTIONS_OBJC_DECLARATION =
   '- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions\n{';
+const IMPORT_OBJC_BATCH = '\n\n#import <RNBatchPush/RNBatch.h>\n';
+const REGISTER_OBJC_BATCH = '\n  [RNBatch start];\n';
 
-const IMPORT_BATCH = '\n\n#import <RNBatchPush/RNBatch.h>\n';
-const REGISTER_BATCH = '\n  [RNBatch start];\n';
+export const modifyObjCDelegate = (contents: string): string => {
+  return modifyDelegate(contents, IMPORT_OBJC_BATCH, DID_FINISH_LAUNCHING_WITH_OPTIONS_OBJC_DECLARATION, REGISTER_OBJC_BATCH);
+};
 
-export const modifyAppDelegate = (contents: string) => {
-  contents = contents.replace('\n', IMPORT_BATCH);
+// MARK : - Swift
 
-  const [beforeDeclaration, afterDeclaration] = contents.split(DID_FINISH_LAUNCHING_WITH_OPTIONS_DECLARATION);
+const DID_FINISH_LAUNCHING_WITH_OPTIONS_SWIFT_DECLARATION = `@UIApplicationMain
+public class AppDelegate: ExpoAppDelegate {
+  public override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {`;
+const IMPORT_SWIFT_BATCH = '\n\nimport RNBatch\n';
+const REGISTER_SWIFT_BATCH = '\n    RNBatch.start()\n';
 
-  const newAfterDeclaration = DID_FINISH_LAUNCHING_WITH_OPTIONS_DECLARATION.concat(REGISTER_BATCH).concat(afterDeclaration);
+export const modifySwiftDelegate = (contents: string): string => {
+  return modifyDelegate(contents, IMPORT_SWIFT_BATCH, DID_FINISH_LAUNCHING_WITH_OPTIONS_SWIFT_DECLARATION, REGISTER_SWIFT_BATCH);
+};
+
+// MARK : - Common
+
+export const modifyDelegate = (contents: string, importBatch: string, declaration: string, register: string): string => {
+  contents = contents.replace('\n', importBatch);
+
+  const [beforeDeclaration, afterDeclaration] = contents.split(declaration);
+
+  const newAfterDeclaration = declaration.concat(register).concat(afterDeclaration);
 
   contents = beforeDeclaration.concat(newAfterDeclaration);
   return contents;
@@ -22,4 +44,12 @@ export const withReactNativeBatchAppDelegate: ConfigPlugin<object | void> = conf
     config.modResults.contents = modifyAppDelegate(config.modResults.contents);
     return config;
   });
+};
+
+export const modifyAppDelegate = (content: string): string => {
+  return isObjCDelegate(content) ? modifyObjCDelegate(content) : modifySwiftDelegate(content);
+};
+
+const isObjCDelegate = (content: string): boolean => {
+  return content.includes('@interface AppDelegate () <RCTBridgeDelegate>');
 };

--- a/plugin/src/ios/withReactNativeBatchAppDelegate.ts
+++ b/plugin/src/ios/withReactNativeBatchAppDelegate.ts
@@ -19,7 +19,7 @@ public class AppDelegate: ExpoAppDelegate {
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {`;
-const IMPORT_SWIFT_BATCH = '\n\nimport RNBatch\n';
+const IMPORT_SWIFT_BATCH = '\n\nimport RNBatchPush\n';
 const REGISTER_SWIFT_BATCH = '\n    RNBatch.start()\n';
 
 export const modifySwiftDelegate = (contents: string): string => {


### PR DESCRIPTION
10.1.0
----

**Plugin**
- Added Swift/Objective-C compatibility. You can now directly import module `RNBatchPush` into your swift files.

**Expo**
- Added support for Expo SDK 53. Since, as of writing, it is still under preview version, this may not works in future versions.

**Core**
- Fixed an issue where opting the SDK after been opted-out would unexpectedly reset default configurations, such as Do Not Disturb setting.

