### PR TITLE
fix: update Swift delegate method to correctly register RNBatch and m…

### DIFF
--- a/plugin/src/ios/withReactNativeBatchAppDelegate.ts
+++ b/plugin/src/ios/withReactNativeBatchAppDelegate.ts
@@ -13,12 +13,7 @@ export const modifyObjCDelegate = (contents: string): string => {
 
 // MARK : - Swift
 
-const DID_FINISH_LAUNCHING_WITH_OPTIONS_SWIFT_DECLARATION = `@UIApplicationMain
-public class AppDelegate: ExpoAppDelegate {
-  public override func application(
-    _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
-  ) -> Bool {`;
+const DID_FINISH_LAUNCHING_WITH_OPTIONS_SWIFT_DECLARATION = 'return super.application(application, didFinishLaunchingWithOptions: launchOptions)';
 const IMPORT_SWIFT_BATCH = '\n\nimport RNBatchPush\n';
 const REGISTER_SWIFT_BATCH = '\n    RNBatch.start()\n';
 
@@ -31,11 +26,10 @@ export const modifySwiftDelegate = (contents: string): string => {
 export const modifyDelegate = (contents: string, importBatch: string, declaration: string, register: string): string => {
   contents = contents.replace('\n', importBatch);
 
-  const [beforeDeclaration, afterDeclaration] = contents.split(declaration);
+  if (contents.includes(declaration) && !contents.includes(register)) {
+    contents = contents.replace(declaration, `${register}    ${declaration}`);
+  }
 
-  const newAfterDeclaration = declaration.concat(register).concat(afterDeclaration);
-
-  contents = beforeDeclaration.concat(newAfterDeclaration);
   return contents;
 };
 


### PR DESCRIPTION
Hi there,

We got an issue using `@batch.com/react-native-plugin` version `10.1.1` with Expo version `53.0.9` and React native `0.79.2`.

Our `AppDelegate.swift` generated by Expo is malformed at the end with a second `@UIApplicationMain` and you can see an `undefined` statement.

<details>

<summary>AppDelegate.swift</summary>

```swift
import Expo

import RNBatchPush
import React
import ReactAppDependencyProvider

@UIApplicationMain
public class AppDelegate: ExpoAppDelegate {
  var window: UIWindow?

  var reactNativeDelegate: ExpoReactNativeFactoryDelegate?
  var reactNativeFactory: RCTReactNativeFactory?

  public override func application(
    _ application: UIApplication,
    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
  ) -> Bool {
    let delegate = ReactNativeDelegate()
    let factory = ExpoReactNativeFactory(delegate: delegate)
    delegate.dependencyProvider = RCTAppDependencyProvider()

    reactNativeDelegate = delegate
    reactNativeFactory = factory
    bindReactNativeFactory(factory)

#if os(iOS) || os(tvOS)
    window = UIWindow(frame: UIScreen.main.bounds)
    factory.startReactNative(
      withModuleName: "main",
      in: window,
      launchOptions: launchOptions)
#endif

    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
  }

  // Linking API
  public override func application(
    _ app: UIApplication,
    open url: URL,
    options: [UIApplication.OpenURLOptionsKey: Any] = [:]
  ) -> Bool {
    return super.application(app, open: url, options: options) || RCTLinkingManager.application(app, open: url, options: options)
  }

  // Universal Links
  public override func application(
    _ application: UIApplication,
    continue userActivity: NSUserActivity,
    restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
  ) -> Bool {
    let result = RCTLinkingManager.application(application, continue: userActivity, restorationHandler: restorationHandler)
    return super.application(application, continue: userActivity, restorationHandler: restorationHandler) || result
  }
}

class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
  // Extension point for config-plugins

  override func sourceURL(for bridge: RCTBridge) -> URL? {
    // needed to return the correct URL for expo-dev-client.
    bridge.bundleURL ?? bundleURL()
  }

  override func bundleURL() -> URL? {
#if DEBUG
    return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
#else
    return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
#endif
  }
}
@UIApplicationMain
public class AppDelegate: ExpoAppDelegate {
  public override func application(
    _ application: UIApplication,
    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
  ) -> Bool {
    RNBatch.start()
undefined
```

</details>

We ended up to update `plugin/src/ios/withReactNativeBatchAppDelegate.ts` using the same pattern as in your Objectif-c case by targeting `return super.application(application, didFinishLaunchingWithOptions: launchOptions`