### PR TITLE
Add requestNotificationAuthorizationAsync API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+UPCOMING
+----
+
+**Push**
+- Added `BatchPush.requestNotificationAuthorizationAsync()` to request notification authorization and return a promise that resolve with the authorization result.
+
+
 12.1.0
 ----
 

--- a/android/src/main/java/com/batch/batch_rn/RNBatchModule.java
+++ b/android/src/main/java/com/batch/batch_rn/RNBatchModule.java
@@ -251,6 +251,11 @@ public class RNBatchModule extends NativeRNBatchModuleSpec {
     }
 
     @Override
+    public void push_requestNotificationAuthorizationAsync(Promise promise) {
+        Batch.Push.requestNotificationPermission(getReactApplicationContext(), granted -> promise.resolve(granted));
+    }
+
+    @Override
     public void push_requestProvisionalNotificationAuthorization() {
         /* No effect on android */
     }

--- a/ios/RNBatch.mm
+++ b/ios/RNBatch.mm
@@ -191,6 +191,19 @@ static RNBatchEventDispatcher* dispatcher = nil;
     [BatchPush requestNotificationAuthorization];
 }
 
+- (void)push_requestNotificationAuthorizationAsync:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [BatchPush requestNotificationAuthorizationWithCompletionHandler:^(BOOL granted, NSError * _Nullable error) {
+            if (error != nil) {
+                reject(@"BatchBridgeError", @"Failed requesting notification authorization:", error);
+                return;
+            }
+            resolve(@(granted));
+        }];
+    });
+}
+
 - (void)push_requestProvisionalNotificationAuthorization
 {
     [BatchPush requestProvisionalNotificationAuthorization];

--- a/src/BatchPush.ts
+++ b/src/BatchPush.ts
@@ -24,6 +24,13 @@ export const BatchPush = {
   },
 
   /**
+   * Ask users if they want to accept push notifications and resolve with the authorization result.
+   * Required to be able to push users (or use requestProvisionalNotificationAuthorization - ios only).
+   *
+   */
+  requestNotificationAuthorizationAsync: (): Promise<boolean> => RNBatch.push_requestNotificationAuthorizationAsync(),
+
+  /**
    * Ask iOS for provisional notifications (no alert to users).
    * Required to be able to push users (or use requestNotificationAuthorization).
    *

--- a/src/NativeRNBatchModule.ts
+++ b/src/NativeRNBatchModule.ts
@@ -31,6 +31,7 @@ export interface Spec extends TurboModule {
   push_dismissNotifications(): void;
   push_getLastKnownPushToken(): Promise<string | null>;
   push_requestNotificationAuthorization(): void;
+  push_requestNotificationAuthorizationAsync(): Promise<boolean>;
   push_requestProvisionalNotificationAuthorization(): void;
   push_refreshToken(): void;
   push_setShowForegroundNotification(enabled: boolean): void;


### PR DESCRIPTION
- Added `BatchPush.requestNotificationAuthorizationAsync()` to request notification authorization and return a promise that resolve with the authorization result.
