### PR TITLE
SPM Support (experimental)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ UPCOMING
 **Plugin**
 - Updated Batch to 3.4
 
+**Android**
+- Batch now compiles with Android SDK 37 (Android 17 'Cinnamon Bun').
+
 **iOS**
 - Added [experimental Swift Package Manager support](https://reactnative.dev/blog/2026/08/11/react-native-0.87#experimental-swift-package-manager-support-for-ios) for iOS, for apps built with React Native's SPM integration (`npx react-native spm`) instead of CocoaPods. Keep in mind this feature is still experimental and may break in upcoming React Native releases.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 UPCOMING
 ----
 
+**Plugin**
+- Updated Batch to 3.4
+
 **iOS**
 - Added [experimental Swift Package Manager support](https://reactnative.dev/blog/2026/08/11/react-native-0.87#experimental-swift-package-manager-support-for-ios) for iOS, for apps built with React Native's SPM integration (`npx react-native spm`) instead of CocoaPods. Keep in mind this feature is still experimental and may break in upcoming React Native releases.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+UPCOMING
+----
+
+**iOS**
+- Added [experimental Swift Package Manager support](https://reactnative.dev/blog/2026/08/11/react-native-0.87#experimental-swift-package-manager-support-for-ios) for iOS, for apps built with React Native's SPM integration (`npx react-native spm`) instead of CocoaPods. Keep in mind this feature is still experimental and may break in upcoming React Native releases.
+
+
 12.2.0
 ----
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ Starting with v12.0.0, the legacy bridge has been removed and the plugin now req
 
 You may also find this guide useful to review after integration to make sure you're ready to go live: [How can I test the integration on iOS?](https://help.batch.com/en/articles/2669866-how-can-i-test-the-integration-on-ios) / [How can I test the integration on Android?](https://help.batch.com/en/articles/2672749-how-can-i-test-the-integration-on-android)
 
+# Swift Package Manager (iOS, experimental)
+
+The plugin supports React Native's experimental [Swift Package Manager](https://www.swift.org/documentation/package-manager/) integration, for iOS apps that use `npx react-native spm` instead of CocoaPods.
+
+The plugin ships a self-managed `ios/Package.swift`, so no manual scaffolding is required. Install the plugin, then run your app's usual SPM setup:
+
+```sh
+npm install @batch.com/react-native-plugin
+npx react-native spm   # regenerates the SPM autolinking graph
+```
+
+`ios/Package.swift` wires the native [Batch iOS SDK](https://github.com/BatchLabs/Batch-iOS-SDK) as a Swift package dependency.
+
 # Releases
 Release instructions are detailed in [RELEASING.md](https://github.com/BatchLabs/Batch-React-Native-Plugin/blob/master/RELEASING.md).
  

--- a/RNBatchPush.podspec
+++ b/RNBatchPush.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   install_modules_dependencies(s)
 
   s.dependency "React"
-  s.dependency 'Batch', '~> 3.3.0'
+  s.dependency 'Batch', '~> 3.4.0'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end

--- a/RNBatchPush.podspec
+++ b/RNBatchPush.podspec
@@ -10,6 +10,10 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "15.0"
   s.source       = { :git => "git@github.com:BatchLabs/Batch-React-Native-Plugin.git", :tag => "master" }
   s.source_files  = "ios/*.{h,m,mm,swift}"
+  # SPM-only files that must not be compiled into the CocoaPods pod:
+  # - Package.swift would be built as a Swift source (import PackageDescription fails).
+  # - the SPM prefix header is only needed by the SPM build (CocoaPods has its own).
+  s.exclude_files = "ios/Package.swift", "ios/react-native-spm-prefix.h"
   s.requires_arc = true
 
   install_modules_dependencies(s)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 def DEFAULT_MIN_SDK_VERSION                 = 21
-def DEFAULT_COMPILE_SDK_VERSION             = 36
-def DEFAULT_BUILD_TOOLS_VERSION             = "36.0.0"
-def DEFAULT_TARGET_SDK_VERSION              = 36
+def DEFAULT_COMPILE_SDK_VERSION             = 37
+def DEFAULT_BUILD_TOOLS_VERSION             = "37.0.0"
+def DEFAULT_TARGET_SDK_VERSION              = 37
 def DEFAULT_BATCH_SDK_VERSION               = "3.4.+"
 
 def safeExtGet(prop, fallback) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ def DEFAULT_MIN_SDK_VERSION                 = 21
 def DEFAULT_COMPILE_SDK_VERSION             = 36
 def DEFAULT_BUILD_TOOLS_VERSION             = "36.0.0"
 def DEFAULT_TARGET_SDK_VERSION              = 36
-def DEFAULT_BATCH_SDK_VERSION               = "3.3.+"
+def DEFAULT_BATCH_SDK_VERSION               = "3.4.+"
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -1,23 +1,7 @@
 // swift-tools-version: 6.0
 //
 // Swift Package Manager support for @batch.com/react-native-plugin.
-//
-// This is a hand-authored, self-managed manifest: React Native's experimental
-// SPM tooling (`npx react-native spm`) detects it and leaves it untouched
-// (it only regenerates manifests that carry its own AUTO-SCAFFOLDED marker).
-// We own it here because RN's autolinking scaffolder cannot resolve the
-// plugin's external native dependency — the Batch iOS SDK (the podspec's
-// `s.dependency 'Batch'`), which is not an npm package — nor propagate the
-// New Architecture flag to the generated target.
-//
-// Path references to the React Native + codegen packages are resolved from the
-// normalized symlink location the autolinker creates
-// (`<app>/ios/build/generated/autolinking/libs/ReactNativePlugin`), which sits
-// at a fixed depth regardless of this package's own (scoped) node_modules
-// path — hence the plain relative paths below.
-//
-// Requires Xcode 16.3+ (Swift tools 6.1) because the Batch iOS SDK's own
-// Swift package manifest targets swift-tools 6.1.
+
 
 import PackageDescription
 
@@ -35,9 +19,7 @@ let package = Package(
     dependencies: [
         .package(name: "ReactNative", path: "../../../../xcframeworks"),
         .package(name: "React-GeneratedCode", path: "../../../ios"),
-        // Native Batch iOS SDK. Pinned to 3.3.x (major+minor fixed, patch
-        // floats to the latest) to mirror the podspec's `~> 3.3.0`.
-        .package(url: "https://github.com/BatchLabs/Batch-iOS-SDK.git", .upToNextMinor(from: "3.3.0")),
+        .package(url: "https://github.com/BatchLabs/Batch-iOS-SDK.git", .upToNextMinor(from: "3.4.0")),
     ],
     targets: [
         .target(

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -1,0 +1,84 @@
+// swift-tools-version: 6.0
+//
+// Swift Package Manager support for @batch.com/react-native-plugin.
+//
+// This is a hand-authored, self-managed manifest: React Native's experimental
+// SPM tooling (`npx react-native spm`) detects it and leaves it untouched
+// (it only regenerates manifests that carry its own AUTO-SCAFFOLDED marker).
+// We own it here because RN's autolinking scaffolder cannot resolve the
+// plugin's external native dependency — the Batch iOS SDK (the podspec's
+// `s.dependency 'Batch'`), which is not an npm package — nor propagate the
+// New Architecture flag to the generated target.
+//
+// Path references to the React Native + codegen packages are resolved from the
+// normalized symlink location the autolinker creates
+// (`<app>/ios/build/generated/autolinking/libs/ReactNativePlugin`), which sits
+// at a fixed depth regardless of this package's own (scoped) node_modules
+// path — hence the plain relative paths below.
+//
+// Requires Xcode 16.3+ (Swift tools 6.1) because the Batch iOS SDK's own
+// Swift package manifest targets swift-tools 6.1.
+
+import PackageDescription
+
+let package = Package(
+    name: "ReactNativePlugin",
+    platforms: [.iOS(.v15)],
+    products: [
+        // The product name must stay "ReactNativePlugin": RN's autolinker
+        // derives it from the npm package name and references it that way from
+        // the generated aggregate package. The *target* (i.e. the importable
+        // Swift/Clang module) is named "RNBatchPush" so consumers use the same
+        // `import RNBatchPush` under SPM as under CocoaPods.
+        .library(name: "ReactNativePlugin", targets: ["RNBatchPush"]),
+    ],
+    dependencies: [
+        .package(name: "ReactNative", path: "../../../../xcframeworks"),
+        .package(name: "React-GeneratedCode", path: "../../../ios"),
+        // Native Batch iOS SDK. Pinned to 3.3.x (major+minor fixed, patch
+        // floats to the latest) to mirror the podspec's `~> 3.3.0`.
+        .package(url: "https://github.com/BatchLabs/Batch-iOS-SDK.git", .upToNextMinor(from: "3.3.0")),
+    ],
+    targets: [
+        .target(
+            name: "RNBatchPush",
+            dependencies: [
+                .product(name: "ReactHeaders", package: "ReactNative"),
+                .product(name: "ReactNativeHeaders", package: "ReactNative"),
+                .product(name: "ReactNativeDependenciesHeaders", package: "ReactNative"),
+                .product(name: "ReactAppHeaders", package: "React-GeneratedCode"),
+                .product(name: "Batch", package: "Batch-iOS-SDK"),
+            ],
+            path: ".",
+            sources: [
+                "BatchBridgeNotificationCenterDelegate.h",
+                "BatchBridgeNotificationCenterDelegate.m",
+                "RNBatch.h",
+                "RNBatch.mm",
+                "RNBatchEventDispatcher.h",
+                "RNBatchEventDispatcher.mm",
+                "RNBatchOpenedNotificationObserver.h",
+                "RNBatchOpenedNotificationObserver.m",
+            ],
+            publicHeadersPath: ".",
+            cSettings: [
+                .headerSearchPath("."),
+                .unsafeFlags(["-include", "react-native-spm-prefix.h"]),
+                .define("RCT_NEW_ARCH_ENABLED", to: "1"),
+            ],
+            cxxSettings: [
+                .headerSearchPath("."),
+                .unsafeFlags(["-include", "react-native-spm-prefix.h"]),
+                .define("DEBUG", .when(configuration: .debug)),
+                .define("NDEBUG", .when(configuration: .release)),
+                .define("RCT_NEW_ARCH_ENABLED", to: "1"),
+            ],
+            linkerSettings: [
+                .linkedFramework("UIKit"),
+                .linkedFramework("Foundation"),
+                .linkedFramework("CoreGraphics"),
+            ]
+        ),
+    ],
+    cxxLanguageStandard: .cxx20
+)

--- a/ios/react-native-spm-prefix.h
+++ b/ios/react-native-spm-prefix.h
@@ -1,0 +1,13 @@
+// Prefix header for Swift Package Manager builds of @batch.com/react-native-plugin.
+//
+// RN's SPM tooling force-includes a file of this name (via `-include`) to mirror
+// CocoaPods' default prefix header, so Objective-C sources that rely on an
+// implicit Foundation/UIKit import compile under SPM (which has no prefix-header
+// mechanism). The scaffolder generates this automatically for libraries it
+// manages; because our Package.swift is self-managed, we ship it ourselves.
+#ifdef __OBJC__
+#import <Foundation/Foundation.h>
+#if __has_include(<UIKit/UIKit.h>)
+#import <UIKit/UIKit.h>
+#endif
+#endif


### PR DESCRIPTION
**Plugin**
- Updated Batch to 3.4

**iOS**
- Added [experimental Swift Package Manager support](https://reactnative.dev/blog/2026/08/11/react-native-0.87#experimental-swift-package-manager-support-for-ios) for iOS, for apps built with React Native's SPM integration (`npx react-native spm`) instead of CocoaPods. Keep in mind this feature is still experimental and may break in upcoming React Native releases.